### PR TITLE
34 As a game manager I want all flying bullets to be destroyed after a player dies so that there are no double hits

### DIFF
--- a/Lab 4/Assets/Scenes/DEV/JoaoDevLevel.unity
+++ b/Lab 4/Assets/Scenes/DEV/JoaoDevLevel.unity
@@ -188,7 +188,6 @@ GameObject:
   - component: {fileID: 379410826}
   - component: {fileID: 379410829}
   - component: {fileID: 379410828}
-  - component: {fileID: 379410827}
   m_Layer: 0
   m_Name: Managers
   m_TagString: Untagged
@@ -225,19 +224,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   shootingEnabled: 1
   bulletPrefab: {fileID: 3217884554533520243, guid: 865b3be940ff5ea459256a992807513e, type: 3}
---- !u!114 &379410827
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 379410824}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 73fbb0aca99c7964f8607b8bb4e0a115, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  timer: 0
 --- !u!114 &379410828
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Lab 4/Assets/Scripts/Player/PlayerHealth.cs
+++ b/Lab 4/Assets/Scripts/Player/PlayerHealth.cs
@@ -35,12 +35,12 @@ public class PlayerHealth : MonoBehaviour
         if (collision.gameObject.CompareTag("Bullet"))
         {
             TakeDamage(1);
+            collision.gameObject.SetActive(false);
         }
     }
 
     private void TakeDamage(int damage)
     {
-        _bulletManager.ClearBullets();
         _currentLives -= damage;
 
         switch (_currentLives)
@@ -50,6 +50,7 @@ public class PlayerHealth : MonoBehaviour
                 // Remove the player's hat here
                 break;
             case <= 0:
+                _bulletManager.ClearBullets();
                 PlayerDeath();
                 Debug.Log("Player has died");
                 break;


### PR DESCRIPTION
## Stories
https://github.com/GDS1-Group-5-2025/lab4/issues/34

## What does this PR do?

- Changes so that the bullets only get all destroyed when a player dies, not when they lose a hat